### PR TITLE
Allow white space in git username

### DIFF
--- a/src/commands/run-circleci-bundle-update-pr.yml
+++ b/src/commands/run-circleci-bundle-update-pr.yml
@@ -82,7 +82,7 @@ steps:
       command: |
         set -xe
 
-        args="<< parameters.git_user_name >> << parameters.git_user_email >> << parameters.branch >>"
+        args="'<< parameters.git_user_name >>' << parameters.git_user_email >> << parameters.branch >>"
 
         if [ -n "<< parameters.assignees >>" ]; then
           args="$args --assignees << parameters.assignees >>"


### PR DESCRIPTION
## Why?

`circleci-bundle-update-pr` did not work properly when I used a blank name in `git_user_name`.

e.g. `hoge fuga`

The execution result is as follows.

```
#!/bin/bash -eo pipefail
set -xe

args="hoge fuga example@example.com master"

if [ -n "" ]; then
  args="$args --assignees "
fi

if [ -n "" ]; then
  args="$args --reviewers "
fi

if [ -n "" ]; then
  args="$args --labels "
fi


circleci-bundle-update-pr $args
+ args='hoge fuga example@example.com master'
+ '[' -n '' ']'
+ '[' -n '' ']'
+ '[' -n '' ']'
+ circleci-bundle-update-pr hoge fuga example@example.com master
No changes due to bundle update
```

## How

* Around `git_user_name` by single quotes

## How to check operation

Testing is very difficult :confused:

For that reason, we only verified whether single quotes can be used with `circleci-bundle-update-pr`.
I used the actual repository for testing.

```
$ git clone https://github.com/feedforce/feedforce-ruboty.git
$ cd feedforce-ruboty
$ gem i -N circleci-bundle-update-pr
$ CIRCLE_PROJECT_USERNAME=feedforce CIRCLE_PROJECT_REPONAME=feedforce-ruboty GITHUB_ACCESS_TOKEN=<token> CIRCLE_BRANCH=master circleci-bundle-update-pr 'feedforce tech team' <email> master
$ echo $?
0
```

(Some arguments are masked 😜)

Created this PR https://github.com/feedforce/feedforce-ruboty/pull/129.