### PR TITLE
Fixed. can't expand environment variable

### DIFF
--- a/src/commands/run-circleci-bundle-update-pr.yml
+++ b/src/commands/run-circleci-bundle-update-pr.yml
@@ -104,4 +104,4 @@ steps:
         args="$args --duplicate"
         <</ parameters.duplicate >>
 
-        circleci-bundle-update-pr '<< parameters.git_user_name >>' << parameters.git_user_email >> $args
+        circleci-bundle-update-pr "<< parameters.git_user_name >>" << parameters.git_user_email >> $args


### PR DESCRIPTION
# My Setting
```yml
    jobs:
      - ruby-orbs/bundle-update-pr:
          image: "circleci/ruby:2.5.3"
```

If `git_user_name ` is omitted, CircleCI env is used .

https://github.com/sue445/circleci-ruby-orbs/blob/1.3.9/src/commands/run-circleci-bundle-update-pr.yml#L21-L24

# Expected
```
circleci-bundle-update-pr 'CircleCI' circleci@example.com master
```

# Actual log
```
+ circleci-bundle-update-pr '$GIT_USER_NAME' circleci@example.com master
```