### PR TITLE
fix: circleci-bundle-update-pr wrong default value

### DIFF
--- a/src/commands/install-circleci-bundle-update-pr.yml
+++ b/src/commands/install-circleci-bundle-update-pr.yml
@@ -4,7 +4,7 @@ description: |
 parameters:
   version:
     type: string
-    default: ""
+    default: "latest"
     description: "circleci-bundle-update-pr vesion. default is latest"
 
 steps:


### PR DESCRIPTION
The command `circleci-bundle-update-pr` was using the wrong default value.