### PR TITLE
fix: use env_var_name instead of string to secure sensitive data

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ workflows:
 * `branch` : Space separated branches. (e.g. `master develop topic`) (default. `$CIRCLE_BRANCH`)
 * `github_access_token` : Your GitHub personal access token (default. `$GITHUB_ACCESS_TOKEN`)
   * Go to [your account's settings page](https://github.com/settings/tokens/new?description=circleci-bundle-update-pr%20token) and generate a personal access token with "repo" scope
+  * Use the CircleCI UI to set the GITHUB_ACCESS_TOKEN environment variable.
 * `enterprise_octokit_access_token` : Your GitHub Enterprise personal access token (default. `$ENTERPRISE_OCTOKIT_ACCESS_TOKEN`)
+  * Use the CircleCI UI to set the ENTERPRISE_OCTOKIT_ACCESS_TOKEN environment variable.
 * `enterprise_octokit_api_endpoint` : Your GitHub Enterprise api endpoint (e.g. https://www.example.com/api/v3) (default. `$ENTERPRISE_OCTOKIT_API_ENDPOINT`)
 * `no_output_timeout` : Elapsed time the command can run without output. (e.g. 20m, 1.25h, 5s) (default. `10m`)
 

--- a/src/commands/run-circleci-bundle-update-pr.yml
+++ b/src/commands/run-circleci-bundle-update-pr.yml
@@ -31,15 +31,15 @@ parameters:
     default: "$CIRCLE_BRANCH"
     description: "Space separated branches. (e.g. 'master develop topic')"
   github_access_token:
-    type: string
-    default: "$GITHUB_ACCESS_TOKEN"
+    type: env_var_name
+    default: GITHUB_ACCESS_TOKEN
     description: |
-      Your GitHub personal access token.
+      Your GitHub personal access token as an env var on CircleCI.
       Go to your account's settings page (https://github.com/settings/tokens/new?description=circleci-bundle-update-pr%20token) and generate a personal access token with "repo" scope
   enterprise_octokit_access_token:
-    type: string
-    default: "$ENTERPRISE_OCTOKIT_ACCESS_TOKEN"
-    description: "Your GitHub Enterprise personal access token"
+    type: env_var_name
+    default: ENTERPRISE_OCTOKIT_ACCESS_TOKEN
+    description: "Your GitHub Enterprise personal access token as an env var on CircleCI"
   enterprise_octokit_api_endpoint:
     type: string
     default: "$ENTERPRISE_OCTOKIT_API_ENDPOINT"

--- a/src/jobs/bundle-update-pr.yml
+++ b/src/jobs/bundle-update-pr.yml
@@ -52,15 +52,15 @@ parameters:
     default: "$CIRCLE_BRANCH"
     description: "Space separated branches. (e.g. `master develop topic`)"
   github_access_token:
-    type: string
-    default: "$GITHUB_ACCESS_TOKEN"
+    type: env_var_name
+    default: GITHUB_ACCESS_TOKEN
     description: |
-      Your GitHub personal access token.
+      Your GitHub personal access token as an env var on CircleCI.
       Go to your account's settings page (https://github.com/settings/tokens/new?description=circleci-bundle-update-pr%20token) and generate a personal access token with "repo" scope
   enterprise_octokit_access_token:
-    type: string
-    default: "$ENTERPRISE_OCTOKIT_ACCESS_TOKEN"
-    description: "Your GitHub Enterprise personal access token"
+    type: env_var_name
+    default: ENTERPRISE_OCTOKIT_ACCESS_TOKEN
+    description: "Your GitHub Enterprise personal access token as an env var on CircleCI"
   enterprise_octokit_api_endpoint:
     type: string
     default: "$ENTERPRISE_OCTOKIT_API_ENDPOINT"


### PR DESCRIPTION
CircleCI [best practices](https://circleci.com/docs/2.0/orbs-best-practices/#parameters) suggests to use `env_var_name` to secure  sensitive data.