### PR TITLE
[Resolved] `open': can't modify frozen Hash: {} (FrozenError)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,7 @@ workflows:
           attach-workspace: true
           checkout: false
           requires: [orb-tools/pack]
+          context: CircleCI
 
       - smoke_test:
           name: smoke_test (bundler v2.1)
@@ -225,3 +226,4 @@ workflows:
               only: /^[0-9.]+\.0$/
             branches:
               ignore: /.*/
+          context: CircleCI

--- a/src/commands/bundle-install.yml
+++ b/src/commands/bundle-install.yml
@@ -254,6 +254,7 @@ steps:
                     set -xe
 
                     if [ "<< parameters.bundle_gemfile >>" == "Gemfile" ]; then
+                      gem install git --version 1.7.0 --no-document
                       gem install restore_bundled_with --no-document
                       restore-bundled-with
                     fi


### PR DESCRIPTION
v1.8.0+ contains breaking changes and restore_bundled_with donsn't work

I want to fix restore_bundled_with, but https://github.com/packsaddle/ruby-restore_bundled_with is archived...

```
+ restore-bundled-with
E, [2021-01-01T05:27:06.498726 #204] ERROR -- RestoreBundledWith 1.0.0: Please report from here:
E, [2021-01-01T05:27:06.498782 #204] ERROR -- RestoreBundledWith 1.0.0: https://github.com/packsaddle/ruby-restore_bundled_with/issues/new
E, [2021-01-01T05:27:06.498802 #204] ERROR -- RestoreBundledWith 1.0.0: options:
E, [2021-01-01T05:27:06.498819 #204] ERROR -- RestoreBundledWith 1.0.0: {"lockfile"=>"Gemfile.lock", "ref"=>"HEAD", "git_path"=>".", "git_options"=>{}, "new_line"=>"\n", "debug"=>false, "verbose"=>false}
/usr/local/bundle/gems/git-1.8.1/lib/git/base.rb:69:in `open': can't modify frozen Hash: {} (FrozenError)
	from /usr/local/bundle/gems/git-1.8.1/lib/git.rb:304:in `open'
	from /usr/local/bundle/gems/restore_bundled_with-1.0.0/lib/restore_bundled_with/repository.rb:21:in `git'
	from /usr/local/bundle/gems/restore_bundled_with-1.0.0/lib/restore_bundled_with/repository.rb:31:in `fetch_file'
	from /usr/local/bundle/gems/restore_bundled_with-1.0.0/lib/restore_bundled_with/lock.rb:41:in `restore'
	from /usr/local/bundle/gems/restore_bundled_with-1.0.0/lib/restore_bundled_with/cli.rb:36:in `restore'
	from /usr/local/bundle/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
	from /usr/local/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /usr/local/bundle/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
	from /usr/local/bundle/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
	from /usr/local/bundle/gems/restore_bundled_with-1.0.0/exe/restore-bundled-with:5:in `<top (required)>'
	from /usr/local/bundle/bin/restore-bundled-with:23:in `load'
	from /usr/local/bundle/bin/restore-bundled-with:23:in `<main>'
```

c.f. https://app.circleci.com/pipelines/github/sue445/chatwork_mention_task/1621/workflows/66a26a41-2cfb-4381-a82c-350ee941e54b/jobs/7727